### PR TITLE
Get formData files when input is type file

### DIFF
--- a/form2/utils.js
+++ b/form2/utils.js
@@ -32,13 +32,21 @@ export const getFormData = (form) => {
 			if (el.name) {
 				const therules = (new Function(`return ${el.dataset.rules}`))()
 				const rules = therules ? therules : null
+
 				const isCheckbox = (el.type && (el.type == 'checkbox'))
-				const value = isCheckbox
-					? el.checked ? el.value : ''
-					: el.form[el.name].value
-				acc[el.name] = value
+				const isFile = (el.type && (el.type == 'file'))
+
+				if (isCheckbox && el.checked) {
+					return acc[el.name] = el.value
+				}
+
+				if (isFile && el.value) {
+					return acc[el.name] = el.files
+				}
+
+				acc[el.name] = el.value
+
 			}
-			return acc
 		}, {})
 
 	return data


### PR DESCRIPTION
This PR solve the little bug associated with input type files when we have input type files the input need to return `files` propertie not value inside it.